### PR TITLE
CBBI-288: Add property for env-specific test JVM args

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,11 +303,25 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.19.1</version>
+					<configuration>
+						<!-- The intent here is to provide a property that can be set in `settings.xml`,
+							to specify environment-specific JVM arguments for tests. For example, one
+							might want to configure the max heap size and/or proxy server settings for
+							tests run on a system. -->
+						<argLine>${maven-test.jvm-args.env-specific}</argLine>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-failsafe-plugin</artifactId>
 					<version>2.19.1</version>
+					<configuration>
+						<!-- The intent here is to provide a property that can be set in `settings.xml`,
+							to specify environment-specific JVM arguments for tests. For example, one
+							might want to configure the max heap size and/or proxy server settings for
+							tests run on a system. -->
+						<argLine>${maven-test.jvm-args.env-specific}</argLine>
+					</configuration>
 				</plugin>
 				<plugin>
 					<!-- A test code coverage plugin that can operate as a Java agent (and 


### PR DESCRIPTION
This is needed, for example, to specify the proxy server settings for the HealthAPT Jenkins server.

https://issues.hhsdevcloud.us/browse/CBBI-288