### PR TITLE
BLUEBUTTON-526: Update Jenkinsfile for best practices

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+#!/usr/bin/env groovy
+
 /**
  * <p>
  * This is the script that will be run by Jenkins to build and test this
@@ -13,6 +15,10 @@
  * <a href="https://builds.ls.r53.cmsfhir.systems/jenkins/job/bluebutton-parent-pom">bluebutton-parent-pom</a>.
  * </p>
  */
+
+properties([
+	buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: ''))
+])
 
 stage('Checkout') {
 	node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,8 @@
  * </p>
  */
 
-node {
-	stage('Checkout') {
+stage('Checkout') {
+	node {
 		// Grab the commit that triggered the build.
 		checkout scm
 
@@ -23,8 +23,12 @@ node {
 		// are distinguishable from other builds.
 		setPomVersionUsingBuildId()
 	}
-	
-	stage('Build') {
+}
+
+stage('Build') {
+	milestone(label: 'stage_build_start')
+
+	node {
 		mvn "--update-snapshots clean install"
 	}
 }


### PR DESCRIPTION
Addressed these things:

1. Don't keep `node`s busy for longer than necessary.
2. Don't build old commits if newer ones have already been (via `milestone`s).
3. Add a shebang to the top, for IDE syntax and formatting assistance.
4. Try to explicitly disable discarding old builds.

https://jira.cms.gov/browse/BLUEBUTTON-526