### PR TITLE
BLUEBUTTON-467: Updated bluebutton-parent-pom to latest version of AWS SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
 					per http://docs.aws.amazon.com/java-sdk/latest/developer-guide/setup-project-maven.html. -->
 				<groupId>com.amazonaws</groupId>
 				<artifactId>aws-java-sdk-bom</artifactId>
-				<version>1.11.105</version>
+				<version>1.11.434</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Trying to fix <https://stackoverflow.com/questions/52950030/java-hanging-on-fileoutputstream-close-for-s3-to-ec2-download> but this is a good idea, anyways.

https://jira.cms.gov/browse/BLUEBUTTON-467